### PR TITLE
Update cf name var and expose az vars

### DIFF
--- a/examples/required_infra/main.tf
+++ b/examples/required_infra/main.tf
@@ -21,4 +21,7 @@ module "required_infra" {
   vpc_cidr_block       = var.vpc_cidr_block
   public_subnet_cidrs  = var.public_subnet_cidrs
   private_subnet_cidrs = var.private_subnet_cidrs
+
+  public_subnet_az  = var.public_subnet_az
+  private_subnet_az = var.private_subnet_az
 }

--- a/examples/required_infra/variables.tf
+++ b/examples/required_infra/variables.tf
@@ -55,3 +55,15 @@ variable "private_subnet_cidrs" {
   description = "List of cidr blocks to be used for private subnets. Has to be in the vpc cidr block. Cannot conflict with public subnets."
   default     = ["10.0.2.0/24"]
 }
+
+variable "public_subnet_az" {
+  type        = string
+  description = "The az to create the public subnets in."
+  default     = "us-east-1a"
+}
+
+variable "private_subnet_az" {
+  type        = string
+  description = "The az to create the private subnets in."
+  default     = "us-east-1a"
+}

--- a/examples/slurm_required/main.tf
+++ b/examples/slurm_required/main.tf
@@ -26,7 +26,7 @@ module "pcluster" {
   }
 
   deploy_pcluster_api = true
-  name                = "PClusterApi${random_id.suffix.hex}"
+  api_stack_name      = "PClusterApi${random_id.suffix.hex}"
   api_version         = "3.8.0"
 
   deploy_required_infra = true

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,8 @@ module "required_infra" {
   vpc_cidr_block       = var.vpc_cidr_block
   public_subnet_cidrs  = var.public_subnet_cidrs
   private_subnet_cidrs = var.private_subnet_cidrs
+  public_subnet_az     = var.public_subnet_az
+  private_subnet_az    = var.private_subnet_az
 }
 
 module "pcluster_api" {
@@ -54,14 +56,14 @@ module "pcluster_api" {
   source = "./modules/pcluster_api"
 
   region                       = var.region
-  name                         = var.name
+  api_stack_name               = var.name
   api_version                  = var.api_version
   custom_pcluster_template_uri = var.custom_pcluster_template_uri
   parameters                   = var.parameters
 }
 
 module "clusters" {
-  count  = length(var.cluster_configs) > 0 ? 1 : 0
+  count  = (length(var.cluster_configs) > 0) || (var.config_path != "") ? 1 : 0
   source = "./modules/clusters"
 
   template_vars   = var.template_vars

--- a/modules/pcluster_api/main.tf
+++ b/modules/pcluster_api/main.tf
@@ -5,8 +5,8 @@
  *  Deployed using a ParallelCluster API Cloudformation Template.
  */
 
-resource "aws_cloudformation_stack" "parallelcluster" {
-  name               = var.name
+resource "aws_cloudformation_stack" "parallelcluster_api" {
+  name               = var.api_stack_name
   template_url       = local.use_custom_pcluster_template_uri ? var.custom_pcluster_template_uri : local.pcluster_template_uri
   timeout_in_minutes = 10
   capabilities       = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]

--- a/modules/pcluster_api/output.tf
+++ b/modules/pcluster_api/output.tf
@@ -1,4 +1,4 @@
 output "parallelcluster" {
   description = "The ParallelCluster API Cloudformation Stack outputs. Refer to the ParallelCluster documentation to see available outputs."
-  value       = aws_cloudformation_stack.parallelcluster.outputs
+  value       = aws_cloudformation_stack.parallelcluster_api.outputs
 }

--- a/modules/pcluster_api/variables.tf
+++ b/modules/pcluster_api/variables.tf
@@ -4,7 +4,7 @@ variable "region" {
   default     = "us-east-1"
 }
 
-variable "name" {
+variable "api_stack_name" {
   type        = string
   description = "Name of the CloudFormation stack."
   default     = "ParallelCluster"

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,18 @@ variable "private_subnet_cidrs" {
   default     = ["10.0.2.0/24"]
 }
 
+variable "public_subnet_az" {
+  type        = string
+  description = "The az to create the public subnets in."
+  default     = "us-east-1a"
+}
+
+variable "private_subnet_az" {
+  type        = string
+  description = "The az to create the private subnets in."
+  default     = "us-east-1a"
+}
+
 ####################
 ## PCLUSTER API ####
 ####################
@@ -69,7 +81,7 @@ variable "region" {
   default     = "us-east-1"
 }
 
-variable "name" {
+variable "api_stack_name" {
   type        = string
   description = "Name of the ParallelCluster API CloudFormation stack."
   default     = "ParallelCluster"


### PR DESCRIPTION
### Description of changes
Changes the cloudformation resource name to `parallelcluster_api` and the stack name variable name to `api_stack_name` and exposes the az vars.

### Tests
* Run the pcluster_api example with a `stack_name` set

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
