### PR TITLE
[Dependencies] Using exact version matching when declaring dependency to pcluster terraform provider.

### DIFF
--- a/modules/clusters/terraform.tf
+++ b/modules/clusters/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     pcluster = {
       source  = "terraform.local/local/pcluster"
-      version = "~> 3.9.0-1"
+      version = "3.9.0-1"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     pcluster = {
       source  = "terraform.local/local/pcluster"
-      version = "~> 3.9.0-1"
+      version = "3.9.0-1"
     }
   }
 }


### PR DESCRIPTION
### Description of changes
Using exact version matching when declaring dependency to pcluster terraform provider.
Why exact version matching? Because atm we are using X.Y.Z-N as version schema for the provider.
This is going to change in the next weeks, but this change is required to successfully execute terraform init on the main module.

### Tests
* terraform init, previously failing on the main module.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
