### PR TITLE
[Examples] In examples cluster_only and slurm_required, expose api_stack_name and region and set them from tfvars.

### DIFF
--- a/examples/cluster_only/main.tf
+++ b/examples/cluster_only/main.tf
@@ -18,7 +18,8 @@ module "pcluster" {
   source                = "../../."
   deploy_pcluster_api   = false
   deploy_required_infra = false
-  region                = "us-east-1"
+  region                = var.region
+  api_stack_name        = var.api_stack_name
   api_version           = var.api_version
   template_vars         = local.config_vars
   config_path           = "files/pcluster-example-config.yaml"

--- a/examples/slurm_required/main.tf
+++ b/examples/slurm_required/main.tf
@@ -33,7 +33,7 @@ module "pcluster" {
   public_subnet_az      = var.public_subnet_az
   private_subnet_az     = var.private_subnet_az
 
-  region          = "us-east-1"
+  region          = var.region
   template_vars   = local.config_vars
   cluster_configs = local.cluster_configs
   config_path     = "files/pcluster-example-config.yaml"


### PR DESCRIPTION
### Description of changes
In examples ckuster_only and slurm_Required, expose api_stack_name and region and set them from tfvars.
Why not in api_only example? When applying the same change to example api_only, terraform fmt fails with no explicit reason (see [failure](https://github.com/aws-tf/terraform-aws-parallelcluster/actions/runs/8814173010/job/24193451850?pr=22)). After some investigation this is still unclear, so we will consider it out of scope for this PR.

### Tests
* terraform plan of all modified examples.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
4. I have checked that all commits' messages are clear, describing what and why vs how.
5. I have successfully executed lint and tests to prove the quality and correctness of the change.
6. I have added tests to validate the proposed change.
7. I have added the documentation to describe my changes (if appropriate).
8. I have added the necessary entries to the changelog (if appropriate).
9. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
