### PR TITLE
[Tests] Fixes to e2e tests mainly related to customization of PCAPI stack name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ terraform.tfstate
 terraform.tfstate.*
 terraform.tfvars
 terraform.tfbackend
+errored.tfstate

--- a/examples/api_only/main.tf
+++ b/examples/api_only/main.tf
@@ -17,7 +17,7 @@
 module "api" {
   source = "../../modules/pcluster_api"
 
-  api_version = var.api_version
+  api_version    = var.api_version
   api_stack_name = var.api_stack_name
   parameters = {
     EnableIamAdminAccess = "true"

--- a/examples/api_only/main.tf
+++ b/examples/api_only/main.tf
@@ -18,6 +18,7 @@ module "api" {
   source = "../../modules/pcluster_api"
 
   api_version = var.api_version
+  api_stack_name = var.api_stack_name
   parameters = {
     EnableIamAdminAccess = "true"
   }

--- a/examples/api_only/tests/test_apply.tftest.hcl
+++ b/examples/api_only/tests/test_apply.tftest.hcl
@@ -21,7 +21,7 @@ run "test_api_only_apply" {
   command = apply
 
   variables {
-    api_version = "3.9.1"
+    api_version    = "3.9.1"
     api_stack_name = "ParallelCluster-${formatdate("YYYYMMDD-hhmmss", timestamp())}"
   }
 

--- a/examples/api_only/tests/test_apply.tftest.hcl
+++ b/examples/api_only/tests/test_apply.tftest.hcl
@@ -20,6 +20,11 @@ run "test_api_only_apply" {
 
   command = apply
 
+  variables {
+    api_version = "3.9.1"
+    api_stack_name = "ParallelCluster-${formatdate("YYYYMMDD-hhmmss", timestamp())}"
+  }
+
   assert {
     condition     = var.region == "us-east-1"
     error_message = "Region did not default to us-east-1"

--- a/examples/api_only/tests/test_plan.tftest.hcl
+++ b/examples/api_only/tests/test_plan.tftest.hcl
@@ -21,7 +21,7 @@ run "test_api_only_plan" {
   command = plan
 
   variables {
-    api_version = "3.9.1"
+    api_version    = "3.9.1"
     api_stack_name = "ParallelCluster-${formatdate("YYYYMMDD-hhmmss", timestamp())}"
   }
 

--- a/examples/api_only/tests/test_plan.tftest.hcl
+++ b/examples/api_only/tests/test_plan.tftest.hcl
@@ -20,6 +20,11 @@ run "test_api_only_plan" {
 
   command = plan
 
+  variables {
+    api_version = "3.9.1"
+    api_stack_name = "ParallelCluster-${formatdate("YYYYMMDD-hhmmss", timestamp())}"
+  }
+
   assert {
     condition     = var.region == "us-east-1"
     error_message = "Region did not default to us-east-1"

--- a/examples/api_only/variables.tf
+++ b/examples/api_only/variables.tf
@@ -30,3 +30,9 @@ variable "api_version" {
   type        = string
   description = "Version of the ParallelCluster API to deploy."
 }
+
+variable "api_stack_name" {
+  type        = string
+  description = "Name of the CloudFormation stack use to deploy the ParallelCluster API."
+  default     = "ParallelCluster"
+}

--- a/examples/cluster_only/files/cluster-config.yaml
+++ b/examples/cluster_only/files/cluster-config.yaml
@@ -2,12 +2,14 @@ Region: ${region}
 Image:
  Os: alinux2
 HeadNode:
- InstanceType: t3.micro
+ InstanceType: t3.small
  Networking:
-   ElasticIp: true
-   SubnetId: ${subnet} 
+   SubnetId: ${subnet}
  Ssh:
-   KeyName: ${key_pair} 
+   KeyName: ${key_pair}
+ Iam:
+   AdditionalIamPolicies:
+     - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
 Scheduling:
  Scheduler: slurm
  SlurmQueues:
@@ -15,14 +17,14 @@ Scheduling:
      CapacityType: ONDEMAND
      Networking:
        SubnetIds:
-         - ${subnet} 
-       AssignPublicIp: true
+         - ${subnet}
+     Iam:
+       AdditionalIamPolicies:
+         - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
      ComputeResources:
        - Name: compute
-         InstanceType: t3.micro
+         InstanceType: t3.small
          MinCount: 1
          MaxCount: 5
-         DisableSimultaneousMultithreading: true
  SlurmSettings:
-   QueueUpdateStrategy: TERMINATE 
-
+   QueueUpdateStrategy: TERMINATE

--- a/examples/cluster_only/tests/test_apply.tftest.hcl
+++ b/examples/cluster_only/tests/test_apply.tftest.hcl
@@ -20,6 +20,14 @@ run "test_slurm_required_apply" {
 
   command = apply
 
+  variables {
+    api_version = "3.9.1"
+
+    # The test assumes that a PCAPI and a KeyPair exist with the below names.
+    api_stack_name = "ParallelCluster"
+    keypair_id = "aws-parallelcluster-terraform-test"
+  }
+
   assert {
     condition     = var.region == "us-east-1"
     error_message = "Region did not default to us-east-1"

--- a/examples/cluster_only/tests/test_apply.tftest.hcl
+++ b/examples/cluster_only/tests/test_apply.tftest.hcl
@@ -25,7 +25,7 @@ run "test_slurm_required_apply" {
 
     # The test assumes that a PCAPI and a KeyPair exist with the below names.
     api_stack_name = "ParallelCluster"
-    keypair_id = "aws-parallelcluster-terraform-test"
+    keypair_id     = "aws-parallelcluster-terraform-test"
   }
 
   assert {

--- a/examples/cluster_only/tests/test_plan.tftest.hcl
+++ b/examples/cluster_only/tests/test_plan.tftest.hcl
@@ -20,6 +20,14 @@ run "test_slurm_required_plan" {
 
   command = plan
 
+  variables {
+    api_version = "3.9.1"
+
+    # The test assumes that a PCAPI and a KeyPair exist with the below names.
+    api_stack_name = "ParallelCluster"
+    keypair_id = "aws-parallelcluster-terraform-test"
+  }
+
   assert {
     condition     = var.region == "us-east-1"
     error_message = "Region did not default to us-east-1"

--- a/examples/cluster_only/tests/test_plan.tftest.hcl
+++ b/examples/cluster_only/tests/test_plan.tftest.hcl
@@ -25,7 +25,7 @@ run "test_slurm_required_plan" {
 
     # The test assumes that a PCAPI and a KeyPair exist with the below names.
     api_stack_name = "ParallelCluster"
-    keypair_id = "aws-parallelcluster-terraform-test"
+    keypair_id     = "aws-parallelcluster-terraform-test"
   }
 
   assert {

--- a/examples/cluster_only/variables.tf
+++ b/examples/cluster_only/variables.tf
@@ -17,11 +17,13 @@
 variable "region" {
   description = "The region the API gateway is deployed in."
   type        = string
+  default     = "us-east-1"
 }
 
 variable "cluster_region" {
   description = "The region the clusters will be deployed in."
   type        = string
+  default     = "us-east-1"
 }
 
 variable "profile" {

--- a/examples/cluster_only/variables.tf
+++ b/examples/cluster_only/variables.tf
@@ -34,12 +34,12 @@ variable "profile" {
 
 variable "keypair_id" {
   type        = string
-  description = "The id of the keypair to be used for the parallelcluster instances."
+  description = "The id of the keypair to be used for the ParallelCluster instances."
 }
 
 variable "subnet_id" {
   type        = string
-  description = "The id of the subnet to be used for the parallelcluster instances."
+  description = "The id of the subnet to be used for the ParallelCluster instances."
 }
 
 variable "api_stack_name" {

--- a/examples/slurm_required/files/cluster-config.yaml
+++ b/examples/slurm_required/files/cluster-config.yaml
@@ -1,28 +1,30 @@
 Region: ${region}
 Image:
- Os: alinux2
+  Os: alinux2
 HeadNode:
- InstanceType: t3.micro
- Networking:
-   ElasticIp: true
-   SubnetId: ${subnet} 
- Ssh:
-   KeyName: ${key_pair} 
+  InstanceType: t3.small
+  Networking:
+    SubnetId: ${subnet}
+  Ssh:
+    KeyName: ${key_pair}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
 Scheduling:
- Scheduler: slurm
- SlurmQueues:
-   - Name: queue1
-     CapacityType: ONDEMAND
-     Networking:
-       SubnetIds:
-         - ${subnet} 
-       AssignPublicIp: true
-     ComputeResources:
-       - Name: compute
-         InstanceType: t3.micro
-         MinCount: 1
-         MaxCount: 5
-         DisableSimultaneousMultithreading: true
- SlurmSettings:
-   QueueUpdateStrategy: TERMINATE 
-
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      CapacityType: ONDEMAND
+      Networking:
+        SubnetIds:
+          - ${subnet}
+      Iam:
+        AdditionalIamPolicies:
+          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      ComputeResources:
+        - Name: compute
+          InstanceType: t3.small
+          MinCount: 1
+          MaxCount: 5
+  SlurmSettings:
+    QueueUpdateStrategy: TERMINATE

--- a/examples/slurm_required/main.tf
+++ b/examples/slurm_required/main.tf
@@ -26,7 +26,7 @@ module "pcluster" {
   }
 
   deploy_pcluster_api = true
-  api_stack_name      = "PClusterApi${random_id.suffix.hex}"
+  api_stack_name      = var.api_stack_name != null ? var.api_stack_name : "PClusterApi-${random_id.suffix.hex}"
   api_version         = var.api_version
 
   deploy_required_infra = true

--- a/examples/slurm_required/terraform_defined_clusters.tf
+++ b/examples/slurm_required/terraform_defined_clusters.tf
@@ -9,13 +9,17 @@ locals {
           Os : "alinux2"
         }
         HeadNode : {
-          InstanceType : "t3.micro"
+          InstanceType : "t3.small"
           Networking : {
-            ElasticIp : true
             SubnetId : local.config_vars.subnet
           }
           Ssh : {
-            KeyName : local.config_vars.key_pair
+            KeyName : local.config_vars.key_pair,
+          }
+          Iam : {
+            AdditionalIamPolicies : [
+              { Policy : "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" }
+            ]
           }
         }
         Scheduling : {
@@ -25,14 +29,17 @@ locals {
             CapacityType : "ONDEMAND"
             Networking : {
               SubnetIds : [local.config_vars.subnet]
-              AssignPublicIp : true
+            }
+            Iam : {
+              AdditionalIamPolicies : [
+                { Policy : "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" }
+              ]
             }
             ComputeResources : [{
               Name : "compute"
-              InstanceType : "t3.micro"
+              InstanceType : "t3.small"
               MinCount : "1"
               MaxCount : "4"
-              DisableSimultaneousMultithreading : true
             }]
           }]
           SlurmSettings : {

--- a/examples/slurm_required/tests/test_apply.tftest.hcl
+++ b/examples/slurm_required/tests/test_apply.tftest.hcl
@@ -20,6 +20,11 @@ run "test_slurm_required_apply" {
 
   command = apply
 
+  variables {
+    api_version = "3.9.1"
+    api_stack_name = "ParallelCluster-${formatdate("YYYYMMDD-hhmmss", timestamp())}"
+  }
+
   assert {
     condition     = var.region == "us-east-1"
     error_message = "Region did not default to us-east-1"

--- a/examples/slurm_required/tests/test_apply.tftest.hcl
+++ b/examples/slurm_required/tests/test_apply.tftest.hcl
@@ -21,7 +21,7 @@ run "test_slurm_required_apply" {
   command = apply
 
   variables {
-    api_version = "3.9.1"
+    api_version    = "3.9.1"
     api_stack_name = "ParallelCluster-${formatdate("YYYYMMDD-hhmmss", timestamp())}"
   }
 

--- a/examples/slurm_required/tests/test_plan.tftest.hcl
+++ b/examples/slurm_required/tests/test_plan.tftest.hcl
@@ -21,7 +21,7 @@ run "test_slurm_required_plan" {
   command = plan
 
   variables {
-    api_version = "3.9.1"
+    api_version    = "3.9.1"
     api_stack_name = "ParallelCluster-${formatdate("YYYYMMDD-hhmmss", timestamp())}"
   }
 

--- a/examples/slurm_required/tests/test_plan.tftest.hcl
+++ b/examples/slurm_required/tests/test_plan.tftest.hcl
@@ -20,6 +20,11 @@ run "test_slurm_required_plan" {
 
   command = plan
 
+  variables {
+    api_version = "3.9.1"
+    api_stack_name = "ParallelCluster-${formatdate("YYYYMMDD-hhmmss", timestamp())}"
+  }
+
   assert {
     condition     = var.region == "us-east-1"
     error_message = "Region did not default to us-east-1"

--- a/examples/slurm_required/variables.tf
+++ b/examples/slurm_required/variables.tf
@@ -42,3 +42,9 @@ variable "api_version" {
   type        = string
   description = "Version of the ParallelCluster API to deploy."
 }
+
+variable "api_stack_name" {
+  type        = string
+  description = "Name of the CloudFormation stack use to deploy the ParallelCluster API."
+  default     = "ParallelCluster"
+}

--- a/modules/pcluster_api/tests/test_plan.tftest.hcl
+++ b/modules/pcluster_api/tests/test_plan.tftest.hcl
@@ -23,13 +23,14 @@ provider "aws" {
 run "test_parallelcluster_plan" {
 
   variables {
-    name = "Test_Cluster"
+    api_stack_name = "ParallelCluster"
+    api_version = "3.9.1"
   }
 
   command = plan
 
   assert {
-    condition     = aws_cloudformation_stack.parallelcluster.name == "Test_Cluster"
+    condition     = aws_cloudformation_stack.parallelcluster_api.name == "ParallelCluster"
     error_message = "ParallelCluster API name does not equal Test_Cluster."
   }
 }

--- a/modules/pcluster_api/tests/test_plan.tftest.hcl
+++ b/modules/pcluster_api/tests/test_plan.tftest.hcl
@@ -24,7 +24,7 @@ run "test_parallelcluster_plan" {
 
   variables {
     api_stack_name = "ParallelCluster"
-    api_version = "3.9.1"
+    api_version    = "3.9.1"
   }
 
   command = plan


### PR DESCRIPTION
### Description of changes
Fixed e2etests covering examples and modules.
Added the possibility to specify PCAPI stack name in tests to avoid resource collisions.
1. Add variable 'api_stack_name' to customize PCAPI stack name.
1. Fix tests covering the examples (api_only, cluster_only, slurm_required) and module pcluster_api by setting the variables appropriately.
1. Simplified cluster configurations used in examples and tests: removed unnecessary configurations, use t3.small instances as in other places of the terraform repos (t3.micro causes too much latency during cluster bootstrap) and add AmazonSSMManagedInstanceCore policy.
1. Replace 'parallelcluster' with 'ParallelCluster' in description of variables.
1. Add to gitignore: errored.tfstate.


**Note** E2E test are expected to fail because they are not supposed to run within a PR but after pushes (see https://github.com/aws-tf/terraform-aws-parallelcluster/pull/28).

### Tests
* All tests executed in personal account.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
3. I have made the PR point to **the right branch**.
4. I have added the right labels to the PR.
5. I have checked that all commits' messages are clear, describing what and why vs how.
6. I have successfully executed lint and tests to prove the quality and correctness of the change.
7. I have added tests to validate the proposed change.
8. I have added the documentation to describe my changes (if appropriate).
9. I have added the necessary entries to the changelog (if appropriate).
10. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
