### PR TITLE
[Test] Fix end2end tests by setting missing variables and installing the provider locally in the github workflow

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -49,6 +49,20 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
+      - name: Checkout Provider Repository
+        uses: actions/checkout@v4
+        with:
+          repository: aws-tf/terraform-provider-aws-parallelcluster
+          ref: main
+          path: provider
+      - name: Setup Go 1.22.0
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.0
+      - name: Install Provider
+        run: |
+          cd provider
+          make install
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/examples/cluster_only/tests/setup/main.tf
+++ b/examples/cluster_only/tests/setup/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}
+
+resource "aws_default_subnet" "default_az1" {
+  availability_zone = "us-east-1a"
+}
+
+output "subnet_id" {
+  value = aws_default_subnet.default_az1.id
+}

--- a/examples/cluster_only/tests/test_apply.tftest.hcl
+++ b/examples/cluster_only/tests/test_apply.tftest.hcl
@@ -16,6 +16,12 @@
 
 variables {}
 
+run "setup_tests" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
 run "test_cluster_only_apply" {
 
   command = apply
@@ -26,6 +32,7 @@ run "test_cluster_only_apply" {
     # The test assumes that a PCAPI and a KeyPair exist with the below names.
     api_stack_name = "ParallelCluster"
     keypair_id     = "aws-parallelcluster-terraform-test"
+    subnet_id      = run.setup_tests.subnet_id
   }
 
   assert {

--- a/examples/cluster_only/tests/test_apply.tftest.hcl
+++ b/examples/cluster_only/tests/test_apply.tftest.hcl
@@ -16,7 +16,7 @@
 
 variables {}
 
-run "test_slurm_required_apply" {
+run "test_cluster_only_apply" {
 
   command = apply
 

--- a/examples/cluster_only/tests/test_plan.tftest.hcl
+++ b/examples/cluster_only/tests/test_plan.tftest.hcl
@@ -16,7 +16,7 @@
 
 variables {}
 
-run "test_slurm_required_plan" {
+run "test_cluster_only_plan" {
 
   command = plan
 

--- a/examples/cluster_only/tests/test_plan.tftest.hcl
+++ b/examples/cluster_only/tests/test_plan.tftest.hcl
@@ -16,6 +16,12 @@
 
 variables {}
 
+run "setup_tests" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
 run "test_cluster_only_plan" {
 
   command = plan
@@ -26,6 +32,7 @@ run "test_cluster_only_plan" {
     # The test assumes that a PCAPI and a KeyPair exist with the below names.
     api_stack_name = "ParallelCluster"
     keypair_id     = "aws-parallelcluster-terraform-test"
+    subnet_id      = run.setup_tests.subnet_id
   }
 
   assert {

--- a/examples/required_infra/tests/test_apply.tftest.hcl
+++ b/examples/required_infra/tests/test_apply.tftest.hcl
@@ -16,7 +16,7 @@
 
 variables {}
 
-run "test_infra_only_plan" {
+run "test_required_infra_plan" {
 
   command = apply
 

--- a/examples/required_infra/tests/test_plan.tftest.hcl
+++ b/examples/required_infra/tests/test_plan.tftest.hcl
@@ -16,7 +16,7 @@
 
 variables {}
 
-run "test_infra_only_plan" {
+run "test_required_infra_plan" {
 
   command = plan
 

--- a/tests/test_plan.tftest.hcl
+++ b/tests/test_plan.tftest.hcl
@@ -31,6 +31,7 @@ run "test_required_infra_plan" {
     deploy_required_infra = true
     deploy_pcluster_api   = false
     cluster_configs       = {}
+    api_version           = "3.9.1"
   }
 
   command = plan

--- a/tests/test_plan.tftest.hcl
+++ b/tests/test_plan.tftest.hcl
@@ -57,6 +57,7 @@ run "test_pcluster_api_plan" {
     deploy_required_infra = false
     deploy_pcluster_api   = true
     cluster_configs       = {}
+    api_version           = "3.9.1"
   }
 
   command = plan


### PR DESCRIPTION
### Description of changes
Fix end2end tests by:
1. setting missing variables 
2. making GH workflow able to use the provider installed locally
3. fixed wrong test names

### Tests
* Executed in forked repo: https://github.com/gmarciani/terraform-aws-parallelcluster/actions/runs/9268111051/job/25496050310 (failure on examples/slurm_required is expected)

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
3. I have made the PR point to **the right branch**.
5. I have added the right labels to the PR.
6. I have checked that all commits' messages are clear, describing what and why vs how.
7. I have successfully executed lint and tests to prove the quality and correctness of the change.
8. I have added tests to validate the proposed change.
9. I have added the documentation to describe my changes (if appropriate).
10. I have added the necessary entries to the changelog (if appropriate).
11. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
