### PR TITLE
[Test] Make the E2E test workflow able to conditionally use the local provider instead of the one fetched from Terraform Registry

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -16,6 +16,26 @@ on:
         required: false
         default: ''
         type: string
+      provider_from_repo:
+        description: |
+          provider_from_repo: if True, the provider will be fetched from the repository and ref specified by
+          'provider_repo' and 'provider_ref'.
+          If False, the provider from Terraform REgistry will be used.
+        required: true
+        default: false
+        type: boolean
+      provider_repo:
+        description: |
+          provider_repo: the repository to checkout for the provider.
+        required: false
+        default: 'aws-tf/terraform-provider-aws-parallelcluster'
+        type: string
+      provider_ref:
+        description: |
+          provider_ref: the branch, tag or SHA to checkout for the provider.
+        required: false
+        default: 'main'
+        type: string
 
 permissions:
   id-token: write
@@ -53,9 +73,10 @@ jobs:
       - name: Checkout Provider Repository
         uses: actions/checkout@v4
         with:
-          repository: aws-tf/terraform-provider-aws-parallelcluster
-          ref: main
+          repository: ${{ inputs.provider_repo }}
+          ref: ${{ inputs.provider_ref }}
           path: provider
+        if:  ${{ inputs.provider_from_repo == true }}
       - name: Setup Go 1.22.0
         uses: actions/setup-go@v5
         with:
@@ -64,6 +85,10 @@ jobs:
         run: |
           cd provider
           make install
+        if:  ${{ inputs.provider_from_repo == true }}
+      - name: Switch to local Provider
+        run: bash tools/use-local-provider.sh
+        if: ${{ inputs.provider_from_repo == true }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/tools/use-local-provider.sh
+++ b/tools/use-local-provider.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# This script makes the modules and examples to use the local installation of the provider
+# rather than the official one vended on Terraform Registry.
+# The changes made by this script are ONLY FOR TESTING AND MUST NOT BE PUSHED TO THE REPOSITORY.
+#
+# In practice, it replaces:
+#
+#   required_providers {
+#     aws-parallelcluster = {
+#       source  = "aws-tf/aws-parallelcluster"
+#     }
+#   }
+#
+# with:
+#   required_providers {
+#     aws-parallelcluster = {
+#       source  = "terraform.local/local/aws-parallelcluster"
+#     }
+#   }
+#
+# Usage:  ./use-local-provider.sh
+
+set -e
+
+PROJECT_DIR="$(dirname "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )")"
+
+SED_CMD=sed
+
+# On Mac OS, the default implementation of sed is BSD sed, but this script requires GNU sed.
+if [ "$(uname)" == "Darwin" ]; then
+  command -v gsed >/dev/null 2>&1 || { echo >&2 "[ERROR] Mac OS detected: please install GNU sed with 'brew install gnu-sed'"; exit 1; }
+  SED_CMD=gsed
+fi
+
+_FILES=(
+  "$PROJECT_DIR/terraform.tf"
+  "$PROJECT_DIR/examples/clusters/terraform.tf"
+  "$PROJECT_DIR/examples/full/terraform.tf"
+  "$PROJECT_DIR/modules/clusters/terraform.tf"
+)
+
+for _file in "${_FILES[@]}"; do
+   echo "Switching to local provider in $_file"
+   $SED_CMD -i 's/aws-tf\/aws-parallelcluster/terraform.local\/local\/aws-parallelcluster/' "$_file"
+done


### PR DESCRIPTION
### Description of changes
Make the E2E test workflow able to conditionally use the local provider instead of the one fetched from Terraform Registry.
This is important to validate that potentially disruptive changes in the provider candidate do not impact the module.
To this aim we needed to:
1. add a tool to let the module switch from the provider vended on Terraform Registry (TFR) to a local one
2. adapt the E2e test workflow to optionally consume the staging provider rather than the one form TFR.

This is also useful when doing local testing.

### Tests
* E2E test execution with staging provider: https://github.com/gmarciani/terraform-aws-parallelcluster/actions/runs/9500894248

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
3. I have made the PR point to **the right branch**.
4. I have added the right labels to the PR.
5. I have checked that all commits' messages are clear, describing what and why vs how.
6. I have successfully executed lint and tests to prove the quality and correctness of the change.
7. I have added tests to validate the proposed change.
8. I have added the documentation to describe my changes (if appropriate).
9. I have added the necessary entries to the changelog (if appropriate).
10. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
