### PR TITLE
[Outputs] Fixes to submodule outputs and updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This project is licensed under the Apache-2.0 License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.5.7 |
-| <a name="requirement_aws-parallelcluster"></a> [aws-parallelcluster](#requirement\_aws-parallelcluster) | 1.0.0-alpha |
+| <a name="requirement_aws-parallelcluster"></a> [aws-parallelcluster](#requirement\_aws-parallelcluster) | ~> 1.0.0 |
 
 ## Providers
 
@@ -106,7 +106,9 @@ No resources.
 |------|-------------|
 | <a name="output_clusters"></a> [clusters](#output\_clusters) | The ParallelCluster clusters. |
 | <a name="output_key_pair"></a> [key\_pair](#output\_key\_pair) | The key pair created for use with AWS ParallelCluster. |
-| <a name="output_parallelcluster"></a> [parallelcluster](#output\_parallelcluster) | The ParallelCluster API Cloudformation Stack outputs. Refer to the ParallelCluster documentation to see available outputs. |
+| <a name="output_pcluster_api_stack_name"></a> [pcluster\_api\_stack\_name](#output\_pcluster\_api\_stack\_name) | The ParallelCluster API Cloudformation Stack name. |
+| <a name="output_pcluster_api_stack_outputs"></a> [pcluster\_api\_stack\_outputs](#output\_pcluster\_api\_stack\_outputs) | The ParallelCluster API Cloudformation Stack outputs. |
+| <a name="output_pcluster_api_stack_parameters"></a> [pcluster\_api\_stack\_parameters](#output\_pcluster\_api\_stack\_parameters) | The ParallelCluster API Cloudformation Stack parameters. |
 | <a name="output_private_key"></a> [private\_key](#output\_private\_key) | The private key used to create the key pair for use with the cluster. |
 | <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | Public subnets. |
 | <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | Private subnets. |

--- a/examples/api/output.tf
+++ b/examples/api/output.tf
@@ -14,6 +14,14 @@
  *
  */
 
-output "parallelcluster" {
-  value = module.api.parallelcluster
+output "pcluster_api_stack_name" {
+  value = module.api.stack_name
+}
+
+output "pcluster_api_stack_parameters" {
+  value = module.api.stack_parameters
+}
+
+output "pcluster_api_stack_outputs" {
+  value = module.api.stack_outputs
 }

--- a/examples/full/outputs.tf
+++ b/examples/full/outputs.tf
@@ -14,6 +14,14 @@
  *
  */
 
-output "parallelcluster" {
-  value = module.pcluster.parallelcluster
+output "pcluster_api_stack_name" {
+  value = module.pcluster.pcluster_api_stack_name
+}
+
+output "pcluster_api_stack_parameters" {
+  value = module.pcluster.pcluster_api_stack_parameters
+}
+
+output "pcluster_api_stack_outputs" {
+  value = module.pcluster.pcluster_api_stack_outputs
 }

--- a/examples/full/provider.tf
+++ b/examples/full/provider.tf
@@ -22,6 +22,6 @@ provider "aws" {
 provider "aws-parallelcluster" {
   region   = var.region
   profile  = var.profile
-  endpoint = module.pcluster.parallelcluster.ParallelClusterApiInvokeUrl
-  role_arn = module.pcluster.parallelcluster.ParallelClusterApiUserRole
+  endpoint = module.pcluster.pcluster_api_stack_outputs.ParallelClusterApiInvokeUrl
+  role_arn = module.pcluster.pcluster_api_stack_outputs.ParallelClusterApiUserRole
 }

--- a/modules/clusters/README.md
+++ b/modules/clusters/README.md
@@ -9,13 +9,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.5.7 |
-| <a name="requirement_aws-parallelcluster"></a> [aws-parallelcluster](#requirement\_aws-parallelcluster) | 1.0.0-alpha |
+| <a name="requirement_aws-parallelcluster"></a> [aws-parallelcluster](#requirement\_aws-parallelcluster) | ~> 1.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws-parallelcluster"></a> [aws-parallelcluster](#provider\_aws-parallelcluster) | 1.0.0-alpha |
+| <a name="provider_aws-parallelcluster"></a> [aws-parallelcluster](#provider\_aws-parallelcluster) | ~> 1.0.0 |
 
 ## Modules
 
@@ -25,8 +25,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws-parallelcluster_cluster.managed_configs](https://registry.terraform.io/providers/aws-tf/aws-parallelcluster/1.0.0-alpha/docs/resources/cluster) | resource |
-| [aws-parallelcluster_cluster.managed_file_configs](https://registry.terraform.io/providers/aws-tf/aws-parallelcluster/1.0.0-alpha/docs/resources/cluster) | resource |
+| aws-parallelcluster_cluster.managed_configs | resource |
+| aws-parallelcluster_cluster.managed_file_configs | resource |
 
 ## Inputs
 
@@ -42,5 +42,5 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_managed"></a> [managed](#output\_managed) | Description of managed clusters. |
+| <a name="output_clusters"></a> [clusters](#output\_clusters) | Description of managed clusters. |
 <!-- END_TF_DOCS -->

--- a/modules/clusters/outputs.tf
+++ b/modules/clusters/outputs.tf
@@ -1,4 +1,4 @@
-output "managed" {
+output "clusters" {
   description = "Description of managed clusters."
   value = merge(
     aws-parallelcluster_cluster.managed_file_configs,

--- a/modules/pcluster_api/README.md
+++ b/modules/pcluster_api/README.md
@@ -43,5 +43,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_parallelcluster"></a> [parallelcluster](#output\_parallelcluster) | The ParallelCluster API Cloudformation Stack outputs. Refer to the ParallelCluster documentation to see available outputs. |
+| <a name="output_stack_name"></a> [stack\_name](#output\_stack\_name) | The ParallelCluster API Cloudformation Stack name. |
+| <a name="output_stack_outputs"></a> [stack\_outputs](#output\_stack\_outputs) | The ParallelCluster API Cloudformation Stack outputs. |
+| <a name="output_stack_parameters"></a> [stack\_parameters](#output\_stack\_parameters) | The ParallelCluster API Cloudformation Stack parameters. |
 <!-- END_TF_DOCS -->

--- a/modules/pcluster_api/output.tf
+++ b/modules/pcluster_api/output.tf
@@ -1,4 +1,14 @@
-output "parallelcluster" {
-  description = "The ParallelCluster API Cloudformation Stack outputs. Refer to the ParallelCluster documentation to see available outputs."
+output "stack_name" {
+  description = "The ParallelCluster API Cloudformation Stack name."
+  value       = aws_cloudformation_stack.parallelcluster_api.name
+}
+
+output "stack_parameters" {
+  description = "The ParallelCluster API Cloudformation Stack parameters."
+  value       = aws_cloudformation_stack.parallelcluster_api.parameters
+}
+
+output "stack_outputs" {
+  description = "The ParallelCluster API Cloudformation Stack outputs."
   value       = aws_cloudformation_stack.parallelcluster_api.outputs
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,12 +39,22 @@ output "private_subnets" {
   value       = try(module.required_infra[0].private_subnets, null)
 }
 
-output "parallelcluster" {
-  description = "The ParallelCluster API Cloudformation Stack outputs. Refer to the ParallelCluster documentation to see available outputs."
-  value       = try(module.pcluster_api[0].parallelcluster, null)
+output "pcluster_api_stack_name" {
+  description = "The ParallelCluster API Cloudformation Stack name."
+  value       = try(module.pcluster_api[0].stack_name, null)
+}
+
+output "pcluster_api_stack_parameters" {
+  description = "The ParallelCluster API Cloudformation Stack parameters."
+  value       = try(module.pcluster_api[0].stack_parameters, null)
+}
+
+output "pcluster_api_stack_outputs" {
+  description = "The ParallelCluster API Cloudformation Stack outputs."
+  value       = try(module.pcluster_api[0].stack_outputs, null)
 }
 
 output "clusters" {
   description = "The ParallelCluster clusters."
-  value       = try(module.clusters[0].managed, null)
+  value       = try(module.clusters[0].clusters, null)
 }


### PR DESCRIPTION
### Description of changes
Fixes to submodule outputs.

In particular:
  1. In submodule clusters, renamed the output 'managed' to 'clusters'.
  2. In submodule pcluster_api, renamed 'parallelcluster' to 'stack_outputs'
  3. In submodule pcluster_api, added output 'stack_name' and 'stack_parameters'

Also, regenerated the documentation with the terraform tool: `terraform-docs markdown ./`

### Tests
* E2E tests: https://github.com/gmarciani/terraform-aws-parallelcluster/actions/runs/9669909894
* Manually verified with demo projects

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. provider, module, cli).
* Link to documentation useful to understand the changes.

### Checklist
By submitting the PR you confirm that you are going to do what follows before merging your code.
1. I have read [CONTRIBUTING](../CONTRIBUTING.md).
2. I have made the PR point to **the right branch**.
3. I have added the right labels to the PR.
5. I have checked that all commits' messages are clear, describing what and why vs how.
6. I have successfully executed lint and tests to prove the quality and correctness of the change.
7. I have added tests to validate the proposed change.
8. I have added the documentation to describe my changes (if appropriate).
9. I have added the necessary entries to the changelog (if appropriate).
10. Any dependent changes have been merged and published in downstream modules.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
